### PR TITLE
Added conversion to Rational.

### DIFF
--- a/src/Data/Approximate/MPFRLowLevel.hs
+++ b/src/Data/Approximate/MPFRLowLevel.hs
@@ -18,7 +18,7 @@ module Data.Approximate.MPFRLowLevel (
   pi,
   isNaN, isInfinite, isZero,
   getExp,
-  toRationalA
+  toRationalA, toDoubleA
 ) where
 import Prelude hiding (isNaN, isInfinite, div, sqrt, exp, log, sin, cos, tan, asin, acos, atan, pi)
 import Data.Bits
@@ -278,6 +278,14 @@ toRationalA r
    | otherwise = s % (1 `shiftL` negate e)
    where (s, e) = decodeFloat' r
 
+foreign import prim "mpfr_cmm_get_d" mpfrGetDouble#
+   :: CRounding# ->
+      CSignPrec# -> CExp# -> ByteArray# ->
+      Double#
+
+toDoubleA :: RoundMode -> Rounded -> Double
+toDoubleA r (Rounded sp e l) =
+    let d = mpfrGetDouble# (mode# r) sp e l in D# d
 
 foreign import prim "mpfr_cmm_get_str" mpfrGetStr#
   :: CRounding# -> Int# -> Int# ->


### PR DESCRIPTION
Dear Ivo, 

I was looking at adding a precision conversion function to ekmett/rounded when I came across your haskell-mpfr fork.  I was happy to find that you have made a nice interface to MPFR along the lines I was looking for.  I am now happily using haskell-mpfr in my current code at https://github.com/michalkonecny/aern2.  Since I need a conversion from Rounded to Rational, I forked haskell-mpfr and added this function.  Please feel free to pull it or otherwise.  Thank you for your work on haskell-mpfr/rounded.

Best regards, Michal
