### PR TITLE
Fix path to mpfr in Setup.hs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ libtool
 /deps/mpfr-*/src/mparam.h
 deps/mpfr-3.1.2/autom4te.cache/
 cabal.sandbox.config
+.stack-work

--- a/Setup.hs
+++ b/Setup.hs
@@ -39,7 +39,7 @@ inDirectory dir action = do
 
 mpfrRoot = "deps/mpfr"
 getMpfrDist = do
-   canonicalizePath "./deps/mpfrBuild"
+   canonicalizePath "./deps/mpfr"
 
 pathsWithSuffix :: String -> FilePath -> IO [FilePath]
 pathsWithSuffix suffix path = do

--- a/src/Data/Approximate/MPFRLowLevel.hs
+++ b/src/Data/Approximate/MPFRLowLevel.hs
@@ -223,7 +223,7 @@ toRationalA r
    | isNaN r  || isInfinite r  = (fromIntegral $ sign r) / 0
    | isZero r = 0   
    | e > 0     = fromIntegral (s `shiftL` e)
-   | otherwise = (fromIntegral s) / (fromIntegral ((1::Int) `shiftL` negate e))
+   | otherwise = (fromIntegral s) / (fromIntegral ((1::Integer) `shiftL` negate e))
    where (s, e) = toInteger2Exp r
 
 foreign import prim "mpfr_cmm_get_d" mpfrGetDouble#


### PR DESCRIPTION
Dear Ivo,

I found that changing the path (as in the commit) fixed the compilation issue on ghc 7.8.4. 

I do not understand the Setup script enough to be sure that this is the correct way to fix the issue.
Also, I have not been able to test it with other versions of ghc.  If you think it is a correct change, please accept the request.

I also found and fixed a bug in toRationalA due to Integer overflow.

Michal
